### PR TITLE
Change apollo atmosphere package version from LATEST to 2.0.0

### DIFF
--- a/apollo/.meteor/packages
+++ b/apollo/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/apollo2/.meteor/packages
+++ b/apollo2/.meteor/packages
@@ -15,7 +15,7 @@ standard-minifier-js@2.3.1    # JS minifier run for production mode
 es5-shim@4.7.0                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.10.0              # Enable ECMAScript2015+ syntax in app code
 
-apollo
+apollo@2.0.0
 
 accounts-password@1.5.0
 

--- a/end of #10/.meteor/packages
+++ b/end of #10/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #11/.meteor/packages
+++ b/end of #11/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #12/.meteor/packages
+++ b/end of #12/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #13/.meteor/packages
+++ b/end of #13/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #14/.meteor/packages
+++ b/end of #14/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #15/.meteor/packages
+++ b/end of #15/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #16/.meteor/packages
+++ b/end of #16/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #17/.meteor/packages
+++ b/end of #17/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #18/.meteor/packages
+++ b/end of #18/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #19/.meteor/packages
+++ b/end of #19/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #20/.meteor/packages
+++ b/end of #20/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #21/.meteor/packages
+++ b/end of #21/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #22/.meteor/packages
+++ b/end of #22/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #23/.meteor/packages
+++ b/end of #23/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #24/.meteor/packages
+++ b/end of #24/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #25/.meteor/packages
+++ b/end of #25/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #26/.meteor/packages
+++ b/end of #26/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #27/.meteor/packages
+++ b/end of #27/.meteor/packages
@@ -16,6 +16,6 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0
 
 accounts-password

--- a/end of #4/.meteor/packages
+++ b/end of #4/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #5/.meteor/packages
+++ b/end of #5/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #6/.meteor/packages
+++ b/end of #6/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #7/.meteor/packages
+++ b/end of #7/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0

--- a/end of #8/.meteor/packages
+++ b/end of #8/.meteor/packages
@@ -16,4 +16,4 @@ es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.9.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.0            # Server-side component of the `meteor shell` command
 
-apollo
+apollo@2.0.0


### PR DESCRIPTION
The version 3.0.0 of atmosphere package apollo has broken the project. I have hardcoded the package version at that same one used when the code was created: 2.0.0. 